### PR TITLE
[fix] VM 로그 출력 안되는 문제 해결 

### DIFF
--- a/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
+++ b/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.security.auth.login.LoginException;
-import java.io.IOException;
+import java.util.List;
 
 @Service
 public class GcpBotService extends ListenerAdapter {
@@ -60,7 +60,18 @@ public class GcpBotService extends ListenerAdapter {
                     break;
 
                 case "logs":
-                    event.getChannel().sendMessage(gcpService.getVmLogs()).queue();
+                    if (parts.length < 3) {
+                        event.getChannel().sendMessage("❌ 사용법: /gcp logs {vm_name}").queue();
+                        return;
+                    }
+                    String logVm = parts[2];
+                    List<String> receivedMessages = gcpService.getVmLogs(logVm);
+                    receivedMessages.forEach(
+                            receiveMessage -> {
+                                event.getChannel().sendMessage(receiveMessage).queue();
+                            }
+                    );
+
                     break;
 
                 case "cost":

--- a/src/main/java/com/gcp/domain/gcp/service/GcpService.java
+++ b/src/main/java/com/gcp/domain/gcp/service/GcpService.java
@@ -81,7 +81,6 @@ public class GcpService {
             headers.setContentType(MediaType.APPLICATION_JSON);
             HttpEntity<Void> request = new HttpEntity<>(headers);
 
-            RestTemplate restTemplate = new RestTemplate();
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);
 
             ObjectMapper mapper = new ObjectMapper();
@@ -104,6 +103,9 @@ public class GcpService {
             headers.setContentType(MediaType.APPLICATION_JSON);
 
             String vmId = getInstanceId(vmName, ZONE);
+            if (vmId == null){
+                return List.of("❌ VM 인스턴스를 찾을 수 없습니다!");
+            }
 
             String filter = String.format(
                     "resource.type=\"gce_instance\" AND resource.labels.instance_id=\"%s\" AND severity>=ERROR",

--- a/src/main/java/com/gcp/domain/gcp/util/GcpAuthUtil.java
+++ b/src/main/java/com/gcp/domain/gcp/util/GcpAuthUtil.java
@@ -17,7 +17,7 @@ public class GcpAuthUtil {
     private final GcpProjectRepository gcpProjectRepository;
 
     public String getAccessToken() throws IOException {
-        String base64EncodedKey = gcpProjectRepository.findByUserId("pjygcp2")
+        String base64EncodedKey = gcpProjectRepository.findByUserId("pjygcp6")
                 .orElseThrow(() -> new RuntimeException("GCP 프로젝트가 등록되지 않았습니다."))
                 .getCredentialsJson();
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- 기존에 /vm logs가 정상적으로 되지 않던 문제 해결 
---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- headers.set("Authorization", "Bearer " + accessToken); -> headers.setBearerAuth(accessToken);
- 테스트 계정에 권한 부여 ( 로그 기록 관리자, 로그 뷰어, 모니터링 관리자, 모니터링 뷰어 )
- 디스코드에서 한 번에 보낼 수 있는 메시지가 최대 2000자라, 2000자를 하나의 Chunk 로 두어 배열에 담고 for 로 하나씩 전송하는 방식으로 수정.
- 변경 전
```
event.getChannel().sendMessage(gcpService.getVmLogs()).queue();
```
- 변경 후 
```
List<String> receivedMessages = gcpService.getVmLogs(logVm);
                    receivedMessages.forEach(
                            receiveMessage -> {
                                event.getChannel().sendMessage(receiveMessage).queue();
                            }
                    );
```
- 로그를 가져오는 쿼리문에는 VM 의 이름이 아니라 ID 가 매개변수라 이름을 통해 ID를 가져오는 함수 추가.
```
public String getInstanceId(String vmName, String zone) {
        try {
            String token = gcpAuthUtil.getAccessToken();
            String url = String.format(
                    "https://compute.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s",
                    PROJECT_ID, zone, vmName
            );

            HttpHeaders headers = new HttpHeaders();
            headers.setBearerAuth(token);
            headers.setContentType(MediaType.APPLICATION_JSON);
            HttpEntity<Void> request = new HttpEntity<>(headers);

            RestTemplate restTemplate = new RestTemplate();
            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);

            ObjectMapper mapper = new ObjectMapper();
            JsonNode json = mapper.readTree(response.getBody());
            return json.path("id").asText();

        } catch (Exception e) {
            log.error("❌ instance_id 조회 실패", e);
            return null;
        }
    }
```
---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #1

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * Discord 봇에서 "logs" 명령어 사용 시 VM 이름을 입력해야 하며, 각 로그 항목이 개별 메시지로 전송됩니다.

* **버그 수정**
  * 로그 메시지가 Discord 메시지 길이 제한(2000자)에 맞게 분할되어 전송됩니다.

* **리팩터링**
  * GCP VM 로그 조회, 시작/중지, 리스트 조회 기능의 내부 요청 처리 방식이 개선되었습니다.

* **기타**
  * GCP 인증에 사용되는 사용자 ID가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->