### PR TITLE
[feat] GCP 방화벽 조회 및 생성, 삭제

### DIFF
--- a/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
+++ b/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
@@ -1,5 +1,6 @@
 package com.gcp.domain.discord.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.gcp.domain.gcp.dto.ProjectZoneDto;
 import com.gcp.domain.gcp.service.GcpProjectCommandService;
 import com.gcp.domain.gcp.service.GcpService;
@@ -16,6 +17,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -172,6 +174,62 @@ public class GcpBotService extends ListenerAdapter {
                 } catch (Exception e) {
                     event.reply("❌ VM 생성 중 오류 발생: " + e.getMessage()).queue();
                 }
+            }
+            case "firewall-list" -> {
+                event.deferReply().queue();
+
+                List<Map<String, Object>> rules = gcpService.getFirewallRules(userId, guildId);
+
+                if (rules.isEmpty()) {
+                    event.getHook().sendMessage("📭 조회된 방화벽 규칙이 없습니다.").queue();
+                    return;
+                }
+
+                StringBuilder sb = new StringBuilder("📌 현재 방화벽 규칙 목록 (TCP 기준):\n");
+
+                for (Map<String, Object> rule : rules) {
+                    String name = (String) rule.get("name");
+                    List<String> ports = (List<String>) rule.get("tcpPorts");
+                    JsonNode sourceRanges = (JsonNode) rule.get("sourceRanges");
+
+                    sb.append("• `").append(name).append("` - 포트: ")
+                            .append(ports.isEmpty() ? "없음" : String.join(", ", ports))
+                            .append(", IP 범위: ").append(sourceRanges.toString()).append("\n");
+                }
+
+                event.getHook().sendMessage(sb.toString()).queue();
+            }
+            case "firewal-create" -> {
+                int port = Optional.ofNullable(event.getOption("port"))
+                        .map(OptionMapping::getAsInt)
+                        .orElseThrow(() -> new IllegalArgumentException("포트가 필요합니다."));
+
+                if (port < 1 || port > 65535) {
+                    event.reply("❌ 유효하지 않은 포트 번호입니다. 1 ~ 65535 사이여야 합니다.").setEphemeral(true).queue();
+                    return;
+                }
+
+                String ipRangeRaw = Optional.ofNullable(event.getOption("source_ranges"))
+                        .map(OptionMapping::getAsString)
+                        .orElse("0.0.0.0/0");
+
+                List<String> sourceRanges = List.of(ipRangeRaw.split("\\s*,\\s*"));
+
+                String result = gcpService.createFirewallRule(userId, guildId, port, sourceRanges);
+                event.reply(result).queue();
+            }
+            case "firewal-delete" -> {
+                int port = Optional.ofNullable(event.getOption("port"))
+                        .map(OptionMapping::getAsInt)
+                        .orElseThrow(() -> new IllegalArgumentException("포트가 필요합니다."));
+
+                if (port < 1 || port > 65535) {
+                    event.reply("❌ 유효하지 않은 포트 번호입니다. 1 ~ 65535 사이여야 합니다.").setEphemeral(true).queue();
+                    return;
+                }
+
+                String result = gcpService.deleteFirewallRule(userId, guildId, port);
+                event.reply(result).queue();
             }
             default -> event.reply("❌ 지원하지 않는 명령어입니다.").queue();
         }

--- a/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
+++ b/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
@@ -199,7 +199,7 @@ public class GcpBotService extends ListenerAdapter {
 
                 event.getHook().sendMessage(sb.toString()).queue();
             }
-            case "firewal-create" -> {
+            case "firewall-create" -> {
                 int port = Optional.ofNullable(event.getOption("port"))
                         .map(OptionMapping::getAsInt)
                         .orElseThrow(() -> new IllegalArgumentException("포트가 필요합니다."));

--- a/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
+++ b/src/main/java/com/gcp/domain/discord/service/GcpBotService.java
@@ -218,7 +218,7 @@ public class GcpBotService extends ListenerAdapter {
                 String result = gcpService.createFirewallRule(userId, guildId, port, sourceRanges);
                 event.reply(result).queue();
             }
-            case "firewal-delete" -> {
+            case "firewall-delete" -> {
                 int port = Optional.ofNullable(event.getOption("port"))
                         .map(OptionMapping::getAsInt)
                         .orElseThrow(() -> new IllegalArgumentException("포트가 필요합니다."));

--- a/src/main/java/com/gcp/global/config/DiscordBotConfig.java
+++ b/src/main/java/com/gcp/global/config/DiscordBotConfig.java
@@ -61,10 +61,10 @@ public class DiscordBotConfig {
                                                 .addOption(OptionType.BOOLEAN, "allow_http", "HTTP 허용 여부", true)
                                                 .addOption(OptionType.BOOLEAN, "allow_https", "HTTPS 허용 여부", true),
                                         new SubcommandData("firewall-list","방화벽 리스트 조회"),
-                                        new SubcommandData("firewal-create", "방화벽 규칙 생성")
+                                        new SubcommandData("firewall-create", "방화벽 규칙 생성")
                                                 .addOption(OptionType.INTEGER, "port", "허용할 포트 번호", true)
                                                 .addOption(OptionType.STRING, "source_ranges", "허용할 IP 범위 (쉼표로 구분)", false),
-                                        new SubcommandData("firewal-delete", "특정 포트를 TCP 기준으로 방화벽에서 삭제")
+                                        new SubcommandData("firewall-delete", "특정 포트를 TCP 기준으로 방화벽에서 삭제")
                                                 .addOption(OptionType.INTEGER, "port", "삭제할 TCP 포트", true)
 
                                 )

--- a/src/main/java/com/gcp/global/config/DiscordBotConfig.java
+++ b/src/main/java/com/gcp/global/config/DiscordBotConfig.java
@@ -59,7 +59,14 @@ public class DiscordBotConfig {
                                                 .addOption(OptionType.STRING, "os_image", "OS 이미지", true)
                                                 .addOption(OptionType.INTEGER, "boot_disk_gb", "부트 디스크 크기(GB)", true)
                                                 .addOption(OptionType.BOOLEAN, "allow_http", "HTTP 허용 여부", true)
-                                                .addOption(OptionType.BOOLEAN, "allow_https", "HTTPS 허용 여부", true)
+                                                .addOption(OptionType.BOOLEAN, "allow_https", "HTTPS 허용 여부", true),
+                                        new SubcommandData("firewall-list","방화벽 리스트 조회"),
+                                        new SubcommandData("firewal-create", "방화벽 규칙 생성")
+                                                .addOption(OptionType.INTEGER, "port", "허용할 포트 번호", true)
+                                                .addOption(OptionType.STRING, "source_ranges", "허용할 IP 범위 (쉼표로 구분)", false),
+                                        new SubcommandData("firewal-delete", "특정 포트를 TCP 기준으로 방화벽에서 삭제")
+                                                .addOption(OptionType.INTEGER, "port", "삭제할 TCP 포트", true)
+
                                 )
                 ).queue();
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->

(TCP 기준)
- 방화벽 조회
- 해당 프로젝트의 방화벽 리스트 조회
<img width="581" height="326" alt="image" src="https://github.com/user-attachments/assets/74991b79-cf79-4df0-9e09-2fcbb6d36956" />

- 방화벽 생성
- 해당 포트와 ip 범위주소 입력. ip 범위 입력하지 않을 시 0.0.0.0/0으로 등록 됨
<img width="591" height="437" alt="image" src="https://github.com/user-attachments/assets/b9646276-316f-428e-a65b-e7d808791135" />


- 방화벽 삭제
- 해당 방화벽 포트 번호를 입력하면 삭제 됨
<img width="617" height="418" alt="image" src="https://github.com/user-attachments/assets/f949efd4-39f9-42c9-ab4a-48c4272375b3" />

---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
-  /gcp firewall-list, /gcp firewall-create, /gcp firewall-delete 명령어 추가 


---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #12 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * GCP 방화벽 규칙을 조회, 생성, 삭제할 수 있는 세 가지 신규 슬래시 명령어가 추가되었습니다.
    * `/gcp firewall-list`로 방화벽 규칙 목록을 확인할 수 있습니다.
    * `/gcp firewall-create`로 지정한 포트와 IP 대역에 대해 방화벽 규칙을 생성할 수 있습니다.
    * `/gcp firewall-delete`로 특정 포트의 방화벽 규칙을 삭제할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->