### PR TITLE
[feat] VM 생성 시 Debian/Ubuntu OS 버전 추가

### DIFF
--- a/src/main/java/com/gcp/domain/gcp/service/GcpService.java
+++ b/src/main/java/com/gcp/domain/gcp/service/GcpService.java
@@ -6,6 +6,7 @@ import com.gcp.domain.discord.entity.DiscordUser;
 import com.gcp.domain.discord.repository.DiscordUserRepository;
 import com.gcp.domain.gcp.dto.ProjectZoneDto;
 import com.gcp.domain.gcp.repository.GcpProjectRepository;
+import com.gcp.domain.gcp.util.GcpImageUtil;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.compute.v1.Project;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
+import static org.json.XMLTokener.entity;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -34,6 +37,7 @@ public class GcpService {
     private final GcpProjectRepository gcpProjectRepository;
     private static final String ZONE = "us-central1-f";
     private static final String PROJECT_ID = "sincere-elixir-464606-j1";
+    private final GcpImageUtil gcpImageUtil;
 
 
     public String startVM(String userId, String guildId, String vmName) {
@@ -304,17 +308,12 @@ public class GcpService {
         log.info("📢 GCP VM 상태 변경 감지 알림 활성화!");
     }
 
-    public String createVM(String userId, String guildId, String vmName, String machineType, String osImage, int bootDiskGb, boolean allowHttp, boolean allowHttps) {
+    public String createVM(String userId, String guildId, String vmName, String machineType, String osFamilyKeyOrLink, int bootDiskGb, boolean allowHttp, boolean allowHttps) {
         try {
             String url = String.format("https://compute.googleapis.com/compute/v1/projects/%s/zones/%s/instances", PROJECT_ID, ZONE);
             String accessToken = discordUserRepository.findAccessTokenByUserIdAndGuildId(userId, guildId).orElseThrow();
+            String sourceImage = gcpImageUtil.resolveLatestSelfLink(accessToken, osFamilyKeyOrLink, "debian-12");
 
-            Map<String, String> imageMap = Map.of(
-                    "debian-11", "projects/debian-cloud/global/images/family/debian-11",
-                    "ubuntu-2204", "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts",
-                    "centos-7", "projects/centos-cloud/global/images/family/centos-7"
-            );
-            String image = imageMap.getOrDefault(osImage, imageMap.get("debian-11"));
 
             List<String> tags = new ArrayList<>();
             if (allowHttp) tags.add("http-server");
@@ -333,7 +332,7 @@ public class GcpService {
                             "autoDelete", true,
                             "initializeParams", Map.of(
                                     "diskSizeGb", bootDiskGb,
-                                    "sourceImage", image
+                                    "sourceImage", sourceImage
                             )
                     )
             ));
@@ -361,7 +360,7 @@ public class GcpService {
             restTemplate.postForEntity(url, entity, String.class);
 
             return "🆕 `" + vmName + "` VM 인스턴스 생성 중 (OS: %s, 디스크: %dGB, HTTP: %s, HTTPS: %s)".formatted(
-                    osImage, bootDiskGb, allowHttp, allowHttps
+                    osFamilyKeyOrLink, bootDiskGb, allowHttp, allowHttps
             );
         } catch (Exception e) {
             log.error("❌ VM 생성 오류", e);

--- a/src/main/java/com/gcp/domain/gcp/util/GcpImageUtil.java
+++ b/src/main/java/com/gcp/domain/gcp/util/GcpImageUtil.java
@@ -52,11 +52,16 @@ public class GcpImageUtil {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
         try {
             ResponseEntity<String> resp = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
             JsonNode image = mapper.readTree(resp.getBody());
-            return image.path("selfLink").asText();
+            String selfLink = image.path("selfLink").asText(null);
+            if (selfLink == null || selfLink.isBlank()) {
+                throw new IllegalStateException("selfLink 파싱 실패: " + image.toString());
+            }
+            return selfLink;
         } catch (Exception e) {
             throw new RuntimeException("family 최신 이미지 조회 실패: " + familyLink, e);
         }

--- a/src/main/java/com/gcp/domain/gcp/util/GcpImageUtil.java
+++ b/src/main/java/com/gcp/domain/gcp/util/GcpImageUtil.java
@@ -1,0 +1,64 @@
+package com.gcp.domain.gcp.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+@Component
+public class GcpImageUtil {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static final Map<String, String> FAMILY_BY_KEY = Map.ofEntries(
+            entry("debian-12", "projects/debian-cloud/global/images/family/debian-12"),
+            entry("debian-11", "projects/debian-cloud/global/images/family/debian-11"),
+
+            entry("ubuntu-2504",     "projects/ubuntu-os-cloud/global/images/family/ubuntu-2504-amd64"),
+            entry("ubuntu-2404-lts", "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"),
+            entry("ubuntu-2204-lts", "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts")
+
+    );
+
+    public List<String> listFamilyKeys() {
+        return FAMILY_BY_KEY.keySet().stream().sorted().toList();
+    }
+
+    public String resolveLatestSelfLink(String accessToken, String familyKeyOrLink, String fallbackFamilyKey) {
+        if (familyKeyOrLink == null || familyKeyOrLink.isBlank()) {
+            familyKeyOrLink = fallbackFamilyKey;
+        }
+
+        if (familyKeyOrLink.startsWith("projects/") && !familyKeyOrLink.contains("/images/family/")) {
+            return familyKeyOrLink;
+        }
+
+        String familyLink = familyKeyOrLink.startsWith("projects/")
+                ? familyKeyOrLink
+                : FAMILY_BY_KEY.getOrDefault(familyKeyOrLink, FAMILY_BY_KEY.get(fallbackFamilyKey));
+
+        return describeFromFamily(accessToken, familyLink);
+    }
+
+    public String describeFromFamily(String accessToken, String familyLink) {
+        String url = "https://compute.googleapis.com/compute/v1/" + familyLink;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        try {
+            ResponseEntity<String> resp = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+            JsonNode image = mapper.readTree(resp.getBody());
+            return image.path("selfLink").asText();
+        } catch (Exception e) {
+            throw new RuntimeException("family 최신 이미지 조회 실패: " + familyLink, e);
+        }
+    }
+}

--- a/src/main/java/com/gcp/global/config/DiscordBotConfig.java
+++ b/src/main/java/com/gcp/global/config/DiscordBotConfig.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,7 +34,9 @@ public class DiscordBotConfig {
                 .build();
 
         jda.awaitReady(); // 명령어 등록 전에 봇이 준비될 때까지 대기
-
+        OptionData osFamilyOption =
+                new OptionData(OptionType.STRING, "os_image", "OS 이미지 선택", true)
+                        .setAutoComplete(true);
 
         jda.updateCommands().addCommands(
                         Commands.slash("gcp", "GCP 관련 명령어")
@@ -56,7 +59,7 @@ public class DiscordBotConfig {
                                         new SubcommandData("create", "VM 생성")
                                                 .addOption(OptionType.STRING, "vm_name", "VM 이름", true)
                                                 .addOption(OptionType.STRING, "machine_type", "머신 타입", true)
-                                                .addOption(OptionType.STRING, "os_image", "OS 이미지", true)
+                                                .addOptions(osFamilyOption)
                                                 .addOption(OptionType.INTEGER, "boot_disk_gb", "부트 디스크 크기(GB)", true)
                                                 .addOption(OptionType.BOOLEAN, "allow_http", "HTTP 허용 여부", true)
                                                 .addOption(OptionType.BOOLEAN, "allow_https", "HTTPS 허용 여부", true),


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->

- GCP VM 생성 시 지원 OS 목록에서 debian, ubuntu 최신 버전 추가 및 CentOS 제거

---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- GCP 이미지 패밀리에 Debian(11, 12), Ubuntu(25.04,22.04 LTS, 24.04 LTS) 버전 추가
- CentOS 이미지 패밀리 삭제
- 명령어 입력 시 OS 자동완성 기능 추가

---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #15 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - VM 생성 명령의 OS 이미지 옵션에 자동완성 지원을 추가하여 입력 편의성을 개선했습니다.
- 개선
  - OS 이미지 선택이 고정 목록에서 최신 이미지 자동 해석 방식으로 전환되어 항상 최신 OS 기반으로 생성됩니다.
  - OS 이미지를 패밀리 키 또는 직접 링크로 지정할 수 있어 유연성이 향상되었습니다.
- 기타
  - 명령 옵션 구성이 재사용 가능하게 정리되어 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->