### PR TITLE
[feat] 프로젝트 ID, 인스턴스 Zone 하드 코딩 제거

### DIFF
--- a/src/main/java/com/gcp/domain/discord/service/DiscordUserService.java
+++ b/src/main/java/com/gcp/domain/discord/service/DiscordUserService.java
@@ -17,9 +17,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.springframework.security.oauth2.core.OAuth2TokenIntrospectionClaimNames.CLIENT_ID;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.CLIENT_SECRET;
-
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/gcp/domain/gcp/service/GcpProjectCommandServiceImpl.java
+++ b/src/main/java/com/gcp/domain/gcp/service/GcpProjectCommandServiceImpl.java
@@ -6,9 +6,11 @@ import com.gcp.domain.gcp.entity.GcpProject;
 import com.gcp.domain.gcp.repository.GcpProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class GcpProjectCommandServiceImpl implements GcpProjectCommandService{
 
     private final GcpProjectRepository gcpProjectRepository;

--- a/src/main/java/com/gcp/domain/gcp/util/GcpZones.java
+++ b/src/main/java/com/gcp/domain/gcp/util/GcpZones.java
@@ -1,0 +1,44 @@
+package com.gcp.domain.gcp.util;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GcpZones {
+
+    public static final Map<String, List<String>> REGIONS = new LinkedHashMap<>() {{
+        put("us-west1", List.of("us-west1-a", "us-west1-b", "us-west1-c"));
+        put("us-west4", List.of("us-west4-a", "us-west4-b", "us-west4-c"));
+        put("us-central1", List.of("us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f"));
+        put("us-east1", List.of("us-east1-b", "us-east1-c", "us-east1-d"));
+        put("us-east4", List.of("us-east4-a", "us-east4-b", "us-east4-c"));
+        put("us-south1", List.of("us-south1-a", "us-south1-b", "us-south1-c"));
+
+        put("europe-west1", List.of("europe-west1-b","europe-west1-c","europe-west1-d"));
+        put("europe-west2", List.of("europe-west2-a","europe-west2-b","europe-west2-c"));
+
+        put("europe-central2", List.of("europe-central2-a","europe-central2-b","europe-central2-c"));
+        put("europe-north1", List.of("europe-north1-a","europe-north1-b","europe-north1-c"));
+        put("europe-southwest1", List.of("europe-southwest1-a","europe-southwest1-b","europe-southwest1-c"));
+
+        put("me-west1", List.of("me-west1-a","me-west1-b","me-west1-c"));
+        put("me-central1", List.of("me-central1-a","me-central1-b","me-central1-c"));
+        put("me-central2", List.of("me-central2-a","me-central2-b","me-central2-c"));
+
+        put("asia-south1", List.of("asia-south1-a","asia-south1-b","asia-south1-c"));
+        put("asia-south2", List.of("asia-south2-a","asia-south2-b","asia-south2-c"));
+        put("asia-southeast1", List.of("asia-southeast1-a","asia-southeast1-b","asia-southeast1-c"));
+        put("asia-southeast2", List.of("asia-southeast2-a","asia-southeast2-b","asia-southeast2-c"));
+
+        put("asia-east1", List.of("asia-east1-a","asia-east1-b","asia-east1-c"));
+        put("asia-east2", List.of("asia-east2-a","asia-east2-b","asia-east2-c"));
+
+        put("asia-northeast1", List.of("asia-northeast1-a","asia-northeast1-b","asia-northeast1-c"));
+        put("asia-northeast2", List.of("asia-northeast2-a","asia-northeast2-b","asia-northeast2-c"));
+
+        put("australia-southeast1", List.of("australia-southeast1-a","australia-southeast1-b","australia-southeast1-c"));
+        put("australia-southeast2", List.of("australia-southeast2-a","australia-southeast2-b","australia-southeast2-c"));
+
+        put("africa-south1", List.of("africa-south1-a","africa-south1-b","africa-south1-c"));
+    }};
+}

--- a/src/main/java/com/gcp/global/config/DiscordBotConfig.java
+++ b/src/main/java/com/gcp/global/config/DiscordBotConfig.java
@@ -38,6 +38,19 @@ public class DiscordBotConfig {
                 new OptionData(OptionType.STRING, "os_image", "OS 이미지 선택", true)
                         .setAutoComplete(true);
 
+        OptionData projectIdOption =
+                new OptionData(OptionType.STRING, "project_id", "프로젝트 ID 입력", true)
+                        .setAutoComplete(true);
+
+
+        OptionData regionOption =
+                new OptionData(OptionType.STRING, "region", "Region 입력", true)
+                        .setAutoComplete(true);
+
+        OptionData zoneOption =
+                new OptionData(OptionType.STRING, "zone", "Zone 입력", true)
+                        .setAutoComplete(true);
+
         jda.updateCommands().addCommands(
                         Commands.slash("gcp", "GCP 관련 명령어")
                                 .addSubcommands(
@@ -48,26 +61,38 @@ public class DiscordBotConfig {
                                                 .addOption(OptionType.STRING, "project_id", "등록하고자 하는 프로젝트 ID", true),
                                         new SubcommandData("zone-list", "프로젝트 내 VM Zone 목록 조회"),
                                         new SubcommandData("start", "VM 시작")
+                                                .addOptions(projectIdOption)
+                                                .addOptions(zoneOption)
                                                 .addOption(OptionType.STRING, "vm_name", "시작할 VM 이름", true),
                                         new SubcommandData("stop", "VM 정지")
+                                                .addOptions(projectIdOption)
+                                                .addOptions(zoneOption)
                                                 .addOption(OptionType.STRING, "vm_name", "정지할 VM 이름", true),
                                         new SubcommandData("logs", "VM 로그 조회")
+                                                .addOptions(projectIdOption)
+                                                .addOptions(zoneOption)
                                                 .addOption(OptionType.STRING, "vm_name", "로그를 볼 VM 이름", true),
-                                        new SubcommandData("cost", "예상 비용 조회"),
-                                        new SubcommandData("notify", "알림 활성화"),
-                                        new SubcommandData("list", "VM 목록 조회"),
+                                        new SubcommandData("list", "VM 목록 조회")
+                                                .addOptions(projectIdOption)
+                                                .addOptions(zoneOption),
                                         new SubcommandData("create", "VM 생성")
                                                 .addOption(OptionType.STRING, "vm_name", "VM 이름", true)
                                                 .addOption(OptionType.STRING, "machine_type", "머신 타입", true)
+                                                .addOptions(projectIdOption)
+                                                .addOptions(regionOption)
+                                                .addOptions(zoneOption)
                                                 .addOptions(osFamilyOption)
                                                 .addOption(OptionType.INTEGER, "boot_disk_gb", "부트 디스크 크기(GB)", true)
                                                 .addOption(OptionType.BOOLEAN, "allow_http", "HTTP 허용 여부", true)
                                                 .addOption(OptionType.BOOLEAN, "allow_https", "HTTPS 허용 여부", true),
-                                        new SubcommandData("firewall-list","방화벽 리스트 조회"),
+                                        new SubcommandData("firewall-list","방화벽 리스트 조회")
+                                                .addOptions(projectIdOption),
                                         new SubcommandData("firewall-create", "방화벽 규칙 생성")
+                                                .addOptions(projectIdOption)
                                                 .addOption(OptionType.INTEGER, "port", "허용할 포트 번호", true)
                                                 .addOption(OptionType.STRING, "source_ranges", "허용할 IP 범위 (쉼표로 구분)", false),
                                         new SubcommandData("firewall-delete", "특정 포트를 TCP 기준으로 방화벽에서 삭제")
+                                                .addOptions(projectIdOption)
                                                 .addOption(OptionType.INTEGER, "port", "삭제할 TCP 포트", true)
 
                                 )


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- DB에 저장된 프로젝트 ID와 GCP API로 불러온 zone 정보로 동적으로 사용자 입력 유도

---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- 기존에 PROJECT_ID와 ZONE 정보가 쓰이던 함수들은 GcpBotService로부터 해당 값들 전달받음.
- 자동완성 명령어 처리 함수에 PROJECT_ID, ZONE 값 불러오는 로직 추가

---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #24 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 모든 슬래시 명령이 프로젝트/리전/존 컨텍스트를 지원해 정밀 제어 가능
  * project_id·region·zone 자동완성 제공(사용자별 프로젝트 제안 포함)
  * VM 시작/중지/목록/로그/생성 시 프로젝트·존 지정 필수
  * 로그 스트리밍 및 생성 진행 상황을 비동기 응답으로 안내
  * 프로젝트별 방화벽 조회/생성/삭제 지원
  * 프로젝트별 존 목록 제공

* 변경 사항
  * zone-list 출력 형식 개선(프로젝트별 응답)
  * cost, notify 명령 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->